### PR TITLE
Fix for issue #2

### DIFF
--- a/src/Confusable.php
+++ b/src/Confusable.php
@@ -143,7 +143,9 @@ class Confusable
                 continue;
             }
 
-            $found = $this->confusablesData[$char];
+            // The original source uses the Python dictionary get() method which returns a default
+            // if the key doesn't exist in the dictionary. This solves issue #2.
+            $found = isset($this->confusablesData[$char]) ? $this->confusablesData[$char] : [];
             // Character λ is considered confusable if λ can be confused with a character from
             // $preferredAliases, e.g. if 'LATIN', 'ρ' is confusable with 'p' from LATIN.
             // if 'LATIN', 'Γ' is not confusable because in all the characters confusable with Γ,

--- a/tests/ConfusableTest.php
+++ b/tests/ConfusableTest.php
@@ -67,23 +67,16 @@ class ConfusableTest extends Base
         // For 'Greek' readers, p is confusable!  ↓
         $confusable = $confusables->isConfusable('paρa', false, ['greek'])[0]['character'];
         $this->assertEquals('p', $confusable);
-    }
 
+        // Microsoft contains a zero width character - added for #2
+        $this->assertTrue(is_array($confusables->isConfusable('www.micros﻿оft.com')));
+        $this->assertTrue(is_array($confusables->isConfusable('www.Αpple.com')));
+        $this->assertTrue(is_array($confusables->isConfusable('www.faϲebook.com')));
 
-    // Temporary test for issue #2, will be merged with testIsConfusable once complete
-    public function testIsConfusableExtra()
-    {
-        try {
-            $categories = new Categories();
-            $confusables = new Confusable($categories);
-        }catch (\Exception $e) {
-            $this->fail($e->getMessage());
-            return;
-        }
-
-        $this->assertTrue(is_array($confusables->isConfusable('www.micros﻿оft.com', false,['latin'])));
-        $this->assertTrue(is_array($confusables->isConfusable('www.Αpple.com', false,['latin'])));
-        $this->assertTrue(is_array($confusables->isConfusable('www.faϲebook.com', false,['latin'])));
+        // The three below are all not confusable - added for #2
+        $this->assertFalse(is_array($confusables->isConfusable('www.microsoft.com', false, ['latin'])));
+        $this->assertFalse(is_array($confusables->isConfusable('www.apple.com', false, ['latin'])));
+        $this->assertFalse(is_array($confusables->isConfusable('www.facebook.com', false, ['latin'])));
     }
 
     public function testIsDangerous()


### PR DESCRIPTION
The Python source uses the [dictionary get](http://www.tutorialspoint.com/python/dictionary_get.htm) method on the loaded json source which returns a sane default.

By wrapping the assignment of `$found` on line 146 (now 148 after comments) with an `isset` check and assigning an empty array by default this issue is fixed.