### PR TITLE
chore: make compatible with PHP 8.4

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: [ '7.3', '7.4', '8.0', '8.1' ]
+        php-versions: [ '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
 
     name: PHP ${{ matrix.php-versions }} Test
 

--- a/src/Categories.php
+++ b/src/Categories.php
@@ -29,7 +29,7 @@ class Categories
      * @param null|string $dataFilePath
      * @throws Exception
      */
-    public function __construct(string $encoding='utf8', string $dataFilePath = null)
+    public function __construct(string $encoding='utf8', ?string $dataFilePath = null)
     {
         if (is_null($dataFilePath)){
             $dataFilePath = __DIR__ . DIRECTORY_SEPARATOR . 'categories.json';

--- a/src/Confusable.php
+++ b/src/Confusable.php
@@ -34,7 +34,7 @@ class Confusable
      * @param null|string $dataFilePath
      * @throws \Exception
      */
-    public function __construct(Categories $categories, string $encoding='utf8', string $dataFilePath = null)
+    public function __construct(Categories $categories, string $encoding='utf8', ?string $dataFilePath = null)
     {
         if (is_null($dataFilePath)){
             $dataFilePath = __DIR__ . DIRECTORY_SEPARATOR . 'confusables.json';


### PR DESCRIPTION
Fixes deprecations introduced in PHP 8.4.

See https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated